### PR TITLE
Default keybinding support for Windows and Linux

### DIFF
--- a/keymaps/fancy-new-file.cson
+++ b/keymaps/fancy-new-file.cson
@@ -7,5 +7,8 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.platform-darwin .workspace':
   'alt-cmd-n': 'fancy-new-file:toggle'
+
+'.platform-win32 .workspace, .platform-linux .workspace':
+  'ctrl-alt-n': 'fancy-new-file:toggle'


### PR DESCRIPTION
Scope default keybindings by .platform-\* selectors so that fancy-new-file works out of the box on Windows and Linux as well as OS X.
