### PR TITLE
OS-specific dir regex

### DIFF
--- a/lib/fancy-new-file-view.coffee
+++ b/lib/fancy-new-file-view.coffee
@@ -102,7 +102,7 @@ class FancyNewFileView extends View
       updatedPath = ""
       if files?.length is 1
         newPath = path.join(@inputPath(), files[0].name)
-        suffix = if files[0].isDir then '/' else ''
+        suffix = if files[0].isDir then path.sep else ''
 
         @updatePath(newPath + suffix)
 
@@ -186,9 +186,9 @@ class FancyNewFileView extends View
     if atom.config.get 'fancy-new-file.suggestCurrentFilePath'
       activePath = atom.workspace.getActiveEditor()?.getPath()
       if activePath
-        activeDir = path.dirname(activePath) + '/'
+        activeDir = path.dirname(activePath) + path.sep
         suggestedPath = path.relative @referenceDir(), activeDir
-        @miniEditor.getEditor().setText suggestedPath + '/'
+        @miniEditor.getEditor().setText suggestedPath + path.sep
 
   toggle: ->
     if @hasParent()

--- a/lib/fancy-new-file-view.coffee
+++ b/lib/fancy-new-file-view.coffee
@@ -26,6 +26,8 @@ class FancyNewFileView extends View
   @detaching: false,
 
   initialize: (serializeState) ->
+    @dirRegex = if path.sep == '/' then /\/$/ else RegExp('\\\\$')
+
     atom.workspaceView.command "fancy-new-file:toggle", => @toggle()
     @miniEditor.setPlaceholderText(path.join('path','to','file.txt'));
 
@@ -124,7 +126,7 @@ class FancyNewFileView extends View
     @getFileList (files) ->
       @renderAutocompleteList files
 
-    if /\/$/.test @miniEditor.getEditor().getText()
+    if @dirRegex.test @miniEditor.getEditor().getText()
       @setMessage 'file-directory-create'
     else
       @setMessage 'file-add'
@@ -151,7 +153,7 @@ class FancyNewFileView extends View
     pathToCreate = path.join(@referenceDir(), relativePath)
 
     try
-      if /\/$/.test(relativePath)
+      if @dirRegex.test(relativePath)
         mkdirp pathToCreate
       else
         atom.open pathsToOpen: [pathToCreate]


### PR DESCRIPTION
Fixes autocomplete behavior on Windows.
Couldn't test it since current master is failing with `no such package mkdirp`.
