### PR TITLE
FIXES `getFileList`.

### DIFF
--- a/lib/fancy-new-file-view.coffee
+++ b/lib/fancy-new-file-view.coffee
@@ -86,7 +86,7 @@ class FancyNewFileView extends View
             not caseSensitive and filename.toLowerCase().indexOf(fragment) is 0
 
           if matches
-            isDir = fs.statSync(path.join(@inputPath(), filename)).isDirectory()
+            try isDir = fs.statSync(path.join(@inputPath(), filename)).isDirectory()
             (if isDir then dirList else fileList).push name:filename, isDir:isDir
 
         if atom.config.get 'fancy-new-file.showFilesInAutoComplete'


### PR DESCRIPTION
- Catch and handle fs exceptions. Errors can happen during the
  iteration if the loop is dealing with weird things like broken links.
# How to replicate the issue:
1. Create an invalid link into the root of your project:
   `$ ln -s ../invalid-file invalid-file`
2. In atom, call the 'fancy-new-file' plugin (example: alt-cmd-n).
3. It should raise: "Uncaught Error: ENOENT, no such file or directory".

Cheers.
