### PR TITLE
Update description: create +or open+ files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fancy-new-file",
   "main": "./lib/fancy-new-file-view",
   "version": "0.8.1",
-  "description": "Create files and directories by typing a relative path.",
+  "description": "Create or open files and directories by typing a relative path.",
   "activationEvents": [
     "fancy-new-file:toggle"
   ],


### PR DESCRIPTION
Both the name and description make this package hard to discover for _opening_ files.

I only found the open functionality when I was about to fork the package to try to add support for it!
