### PR TITLE
Fix and update custom workspace selectors

### DIFF
--- a/keymaps/fancy-new-file.cson
+++ b/keymaps/fancy-new-file.cson
@@ -7,8 +7,8 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.platform-darwin .workspace':
+'.platform-darwin atom-workspace':
   'alt-cmd-n': 'fancy-new-file:toggle'
 
-'.platform-win32 .workspace, .platform-linux .workspace':
+'.platform-win32 atom-workspace, .platform-linux atom-workspace':
   'ctrl-alt-n': 'fancy-new-file:toggle'


### PR DESCRIPTION
Hello,
This commit updates name and usage of custom selectors to 1.0 API:
https://atom.io/docs/v0.189.0/upgrading-to-1-0-apis-upgrading-your-ui-theme-or-package-selectors

Tested on OS X/10.10.*:
![20150406111802](https://cloud.githubusercontent.com/assets/14539/7002682/ea6fb084-dc4e-11e4-8dc3-e9b62bde5345.jpg)

Thanks!
